### PR TITLE
Update readme to honor apt quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ sudo usermod -a -G input <your_username>
 3. Run the application:
 
 ```bash
-wayvibes <soundpack_path> -v <volume(0.0-10.0)>
+wayvibes <soundpack_path> -v <volume(0.0-10.0)> -s
 ```
 
 **Example:** 
 
 ```bash
-wayvibes ~/wayvibes/akko_lavender_purples/ -v 3
+wayvibes ~/wayvibes/akko_lavender_purples/ -v 3 -s
 ```
 
 #### Note:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ yay -S wayvibes-git
 #### Prerequisites:
 Ensure the following dependencies are installed:
 
-- `libevdev` (`libevdev-devel` on debian/fedora)
-- `nlohmann-json` (`nlohmann-json-devel` on debian/fedora)
-- ~`miniaudio`~ (`miniaudio.h` file is present in this project)
+Ubuntu-based distros:
+- `libevdev-dev`
+- `nlohmann-json*-dev`
+
+You can install them easily by running
+`sudo apt install libevdev-dev nlohmann-json*-dev`
+
+Arch:
+- `libevdev`
+- `nlohmann-json`
 
 To install wayvibes, use the following commands: 
 


### PR DESCRIPTION
I'm using Pop_OS 24.04, based on Ubuntu 24.04.

The second dependency has the wrong name, since it's called `nlohmann-json3-dev`; in the commit I put `nlohmann-json*-dev` because someone else may found `nlohmann-json2-dev`, so we'd like to account every possibility... since there's no way you could have two major development packages, I guess.

This PR will also make the readme slightly more readable in that section.

Feel free to correct the "Arch:" part, since I'm not sure it'll just serves to Arch, maybe also for other distros?